### PR TITLE
Fixed confusing naming inconsistency from `iran_addr` to `iran_ip`

### DIFF
--- a/src/foreign_server.nim
+++ b/src/foreign_server.nim
@@ -318,7 +318,7 @@ proc poolController() {.async.} =
     proc connect(upload: bool) {.async.} =
         inc context.pending_free_outbounds
         try:
-            var con_fut = connect(initTAddress(globals.iran_addr, globals.iran_port), SocketScheme.Secure, globals.final_target_domain)
+            var con_fut = connect(initTAddress(globals.iran_ip, globals.iran_port), SocketScheme.Secure, globals.final_target_domain)
             var notimeout = await withTimeout(con_fut, 3.secs)
             if notimeout:
                 var conn = con_fut.read()
@@ -396,7 +396,7 @@ proc poolController() {.async.} =
                 break
 
 proc start*(){.async.} =
-    echo &"Mode Foreign Server:  {globals.self_ip} <-> {globals.iran_addr} ({globals.final_target_domain} with ip {globals.final_target_ip})"
+    echo &"Mode Foreign Server:  {globals.self_ip} <-> {globals.iran_ip} ({globals.final_target_domain} with ip {globals.final_target_ip})"
     context.outbounds_udp.new()
     context.outbounds.new()
     context.up_bounds.new()

--- a/src/globals.nim
+++ b/src/globals.nim
@@ -49,7 +49,7 @@ var listen_addr* = "::"
 var listen_port*: Port = 0.Port
 var next_route_addr* = ""
 var next_route_port*: Port = 0.Port
-var iran_addr* = ""
+var iran_ip* = ""
 var iran_port*: Port = 0.Port
 var final_target_domain* = ""
 var final_target_ip*: string
@@ -252,8 +252,8 @@ proc init*() =
                                 quit("could not parse toport.")
 
                     of "iran-ip":
-                        iran_addr = (p.val)
-                        print iran_addr
+                        iran_ip = (p.val)
+                        print iran_ip
 
                     of "iran-port":
                         iran_port = parseInt(p.val).Port
@@ -349,8 +349,8 @@ proc init*() =
 
     case mode:
         of RunMode.kharej:
-            if iran_addr.isEmptyOrWhitespace():
-                echo "specify the ip address of the iran server --iran-addr:{ip}"
+            if iran_ip.isEmptyOrWhitespace():
+                echo "specify the ip address of the iran server --iran-ip:{ip}"
                 exit = true
             if iran_port == 0.Port and not multi_port:
                 echo "specify the iran server prot --iran-port:{port}"


### PR DESCRIPTION
When running the program in the foreign server, if the IP address of the foreign server is not provided, it complains that the argument `iran-addr` is missing. After providing the argument it still complains about it. Upon further investigation I figured that all of the docs are using `iran-ip` instead of `iran-addr` and it expect the former as well, it just says the wrong thing. There is a naming inconstancy in the `globals.nim` file, I changed all of the `iran_addr`s to `iran_ip` to avoid further confusion. Hope I didn't break anything. 